### PR TITLE
Filtering Pull Requests

### DIFF
--- a/src/services/repository.ts
+++ b/src/services/repository.ts
@@ -76,12 +76,14 @@ export default class Repository {
       issue, { headers: this.#org.headers }
     );
 
+    const filteredIssues = issues.filter((row) => !("pull_request" in row));
+
     return {
       name: full_name,
       pr: pulls
         .filter((row) => row.user !== null)
         .map((row) => row.user!.login),
-      issues: issues
+      issues: filteredIssues
         .filter((row) => row.user !== null)
         .map((row) => row.user!.login)
     };


### PR DESCRIPTION
<strong>Problem</strong>: The GitHub API includes Pull Requests in Issues search results.
<strong>Solution</strong>: To isolate true Issues, a filter checks for the absence of the `pull_request` field in the returned JSON data. Since Pull Requests are Issues with additional information, this field makes it easy to distinguish them.