### PR TITLE
Updated detection of Node and Japa test runners

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/test/getTestFrameworkName.spec.ts
+++ b/test/getTestFrameworkName.spec.ts
@@ -7,11 +7,13 @@ import { getTestFrameworkName } from "../src/utils";
 
 describe("getTestFrameworkName()", () => {
   it("Should return N/A", () => {
-    assert.equal(getTestFrameworkName({ test: "2.0.0", test2: "3.0.0" }), "N/A");
+    assert.equal(getTestFrameworkName({ name: "test", version: "1.0.0", test: "2.0.0", test2: "3.0.0" }), "N/A");
   });
 
   it("Should return ava", () => {
     const packageJson = {
+      name: "test",
+      version: "1.0.0",
       devDependencies: {
         ava: "^2.0.0"
       }
@@ -21,6 +23,8 @@ describe("getTestFrameworkName()", () => {
 
   it("Should return jest", () => {
     const packageJson = {
+      name: "test",
+      version: "1.0.0",
       devDependencies: {
         jest: "^2.0.0"
       }
@@ -30,8 +34,10 @@ describe("getTestFrameworkName()", () => {
 
   it("Should return japa", () => {
     const packageJson = {
+      name: "test",
+      version: "1.0.0",
       devDependencies: {
-        japa: "^2.0.0"
+        "@japa/runner": "^2.0.0"
       }
     };
     assert.equal(getTestFrameworkName(packageJson), "japa");
@@ -39,6 +45,8 @@ describe("getTestFrameworkName()", () => {
 
   it("Should return tape", () => {
     const packageJson = {
+      name: "test",
+      version: "1.0.0",
       devDependencies: {
         tape: "^2.0.0"
       }
@@ -48,6 +56,8 @@ describe("getTestFrameworkName()", () => {
 
   it("Should return mocha", () => {
     const packageJson = {
+      name: "test",
+      version: "1.0.0",
       devDependencies: {
         mocha: "^2.0.0"
       }
@@ -56,12 +66,52 @@ describe("getTestFrameworkName()", () => {
     assert.equal(getTestFrameworkName(packageJson), "mocha");
   });
 
-  it("Should return node:test", () => {
-    const packageJson = {
-      scripts: {
-        test: "node --test"
-      }
-    };
-    assert.equal(getTestFrameworkName(packageJson), "node:test");
+  describe("node:test", () => {
+    it("Should return node:test for test script", () => {
+      const packageJson = {
+        name: "test",
+        version: "1.0.0",
+        scripts: {
+          test: "node --test"
+        }
+      };
+      assert.equal(getTestFrameworkName(packageJson), "node:test");
+    });
+
+    it("Should return node:test when a nested script uses node --test", () => {
+      const packageJson = {
+        name: "test",
+        version: "1.0.0",
+        scripts: {
+          test: "c8 --all --src ./src -r html npm run test-only",
+          "test-only": "glob -c \"node --loader=esmock --no-warnings --test-concurrency 1 --test\" \"test/**/*.test.js\""
+        }
+      };
+      assert.equal(getTestFrameworkName(packageJson), "node:test");
+    });
+
+    it("Should return node:test when a nested script uses node --test, recursively", () => {
+      const packageJson = {
+        name: "test",
+        version: "1.0.0",
+        scripts: {
+          test: "npm run foo",
+          foo: "npm run bar",
+          bar: "node --test"
+        }
+      };
+      assert.equal(getTestFrameworkName(packageJson), "node:test");
+    });
+
+    it("Should return node:test for test script when using tsx", () => {
+      const packageJson = {
+        name: "test",
+        version: "1.0.0",
+        scripts: {
+          test: "tsx --test"
+        }
+      };
+      assert.equal(getTestFrameworkName(packageJson), "node:test");
+    });
   });
 });


### PR DESCRIPTION
This PR aims to improve the detection of test runners used in projects, particularly for Node.js and Japa.

Currently the code only checks the test script in the package.json file. However, in many projects it is the test-only script that is responsible for running the tests. This prevents correct detection of Node's test runner.

Proposed changes:
Test-only script support: The code has been changed to also check the test-only script in the package.json file, in addition to the test script.

Japa verification: As per [Japa documentation](https://japa.dev/docs/installation), the presence of @japa/runner in devDependencies is now checked to identify projects using Japa as a test runner.